### PR TITLE
CI 파이프라인 버그 수정

### DIFF
--- a/.github/workflows/CI_PIPELINE.yml
+++ b/.github/workflows/CI_PIPELINE.yml
@@ -22,10 +22,15 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Fetch base branch
+        run: |
+          echo "BASE_BRANCH=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          git fetch origin $BASE_BRANCH --depth=1
+
       - name: Check for changes in ${{ matrix.project }}
         id: changes
         run: |
-          if git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | grep -q "^${{ matrix.project }}/"; then
+          if git diff --name-only origin/$BASE_BRANCH HEAD | grep -q "^${{ matrix.project }}/"; then
             echo "changed=true" >> $GITHUB_ENV
           else
             echo "changed=false" >> $GITHUB_ENV

--- a/.github/workflows/CI_PIPELINE.yml
+++ b/.github/workflows/CI_PIPELINE.yml
@@ -36,6 +36,21 @@ jobs:
             echo "changed=false" >> $GITHUB_ENV
           fi
 
+      - name: Set up Node.js
+        if: env.changed == 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Cache dependencies for ${{ matrix.project }}
+        if: env.changed == 'true'
+        uses: actions/cache@v3
+        with:
+          path: ${{ matrix.project }}/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', matrix.project)) }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-          
+
       - name: Install Dependencies for ${{ matrix.project }}
         if: env.changed == 'true'
         run: yarn install

--- a/backend/src/config/TypeOrmConfigService.ts
+++ b/backend/src/config/TypeOrmConfigService.ts
@@ -5,8 +5,7 @@ import { CustomNamingStrategy } from './CustomNamingStrategy';
 
 @Injectable()
 export class TypeOrmConfigService implements TypeOrmOptionsFactory {
-  constructor(private configService: ConfigService) {
-  }
+  constructor(private configService: ConfigService) {}
 
   createTypeOrmOptions(): TypeOrmModuleOptions {
     return {

--- a/backend/src/map/exception/MapNotFoundException.ts
+++ b/backend/src/map/exception/MapNotFoundException.ts
@@ -1,0 +1,12 @@
+import { BaseException } from '../../common/exception/BaseException';
+import { HttpStatus } from '@nestjs/common';
+
+export class MapNotFoundException extends BaseException {
+  constructor(id: number) {
+    super({
+      code: 802,
+      message: `id:${id} 지도가 존재하지 않거나 삭제되었습니다.`,
+      status: HttpStatus.NOT_FOUND,
+    });
+  }
+}

--- a/backend/src/map/map.service.ts
+++ b/backend/src/map/map.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { MapListResponse } from './dto/MapListResponse';
 import { MapDetailResponse } from './dto/MapDetailResponse';
+import { MapNotFoundException } from './exception/MapNotFoundException';
 
 @Injectable()
 export class MapService {
@@ -61,7 +62,7 @@ export class MapService {
     const map = await this.mapRepository.findById(id);
     if (map) return await MapDetailResponse.from(map);
 
-    throw new Error('커스텀에러로수정예정 404');
+    throw new MapNotFoundException(id);
   }
 
   async createMap(userId: number, createMapForm: CreateMapForm) {


### PR DESCRIPTION
## 📄 Summary

> base 브랜치와 비교하는 것으로 바꾼 후로, CI 워크플로우에서 변경사항이 제대로 체크되지 않음.

## 🙋🏻 More

## yarn 캐싱 적용해 CI 속도 향상

캐시 적용 전 : 33초 / install 15초

### 캐시 첫 적용 : 2분 48초 / install  14초
![image](https://github.com/user-attachments/assets/62bc1b54-ff89-4924-913c-e91f05509344)
![image](https://github.com/user-attachments/assets/f60ab240-ce86-4ad5-b32d-e671275e430f)

첫 번째 액션에서는 post-cache 액션으로 캐시를 저장하기 위해 시간이 오래 걸리는 것을 확인

### 캐싱 후 액션 : 24초 / 캐시 4초 / install 0초
![image](https://github.com/user-attachments/assets/ef852e66-30e4-4dc3-be9d-8fb6aafb3023)

기존에 14,15초 걸리던 yarn insatll 명령을 4초로 단축  
총 33초 걸리던 CI 파이프라인 액션을 24초로 단축  

### 🕰️ Actual Time of Completion

> 1H

close #47