### PR TITLE
PlaceRepository에서 Repository 대신 SoftDeleteRepository로 리팩토링

### DIFF
--- a/backend/src/common/SoftDeleteRepository.ts
+++ b/backend/src/common/SoftDeleteRepository.ts
@@ -12,53 +12,45 @@ export abstract class SoftDeleteRepository<
   find(options: FindManyOptions<T> = {}) {
     return super.find({
       ...options,
-      where: {
-        ...(options?.where || {}),
-        deletedAt: null,
-      },
+      where: this.applyDeletedAtCondition(options.where),
     });
   }
 
   findById(id: K) {
     return this.findOne({
-      where: {
-        id,
-        deletedAt: null,
-      } as FindOptionsWhere<T>,
+      where: this.applyDeletedAtCondition({ id } as FindOptionsWhere<T>),
     });
   }
 
   findAndCount(options: FindManyOptions<T> = {}) {
     return super.findAndCount({
       ...options,
-      where: {
-        ...(options?.where || {}),
-        deletedAt: null,
-      },
+      where: this.applyDeletedAtCondition(options.where),
     });
   }
 
   count(options: FindManyOptions<T> = {}): Promise<number> {
     return super.count({
       ...options,
-      where: {
-        ...(options?.where || {}),
-        deletedAt: null,
-      },
+      where: this.applyDeletedAtCondition(options.where),
     });
   }
 
   findOne(options: FindManyOptions<T> = {}) {
     return super.findOne({
       ...options,
-      where: {
-        ...(options?.where || {}),
-        deletedAt: null,
-      },
+      where: this.applyDeletedAtCondition(options.where),
     });
   }
 
   softDelete(id: number) {
     return super.update(id, { deletedAt: new Date() } as any);
+  }
+
+  private applyDeletedAtCondition(where: any) {
+    if (Array.isArray(where)) {
+      return where.map((condition) => ({ ...condition, deletedAt: null }));
+    }
+    return { ...where, deletedAt: null };
   }
 }

--- a/backend/src/place/dto/CreatePlaceDto.ts
+++ b/backend/src/place/dto/CreatePlaceDto.ts
@@ -4,6 +4,7 @@ import {
   IsString,
   ValidateNested,
 } from 'class-validator';
+import { Place } from '../place.entity';
 
 export class CreatePlaceDto {
   @IsString()
@@ -35,4 +36,18 @@ export class CreatePlaceDto {
 
   @IsString()
   detailPageUrl?: string;
+
+  toEntity() {
+    return new Place(
+      this.googlePlaceId,
+      this.name,
+      this.thumbnailUrl,
+      this.rating,
+      this.location.longitude,
+      this.location.latitude,
+      this.formattedAddress,
+      this.description,
+      this.detailPageUrl,
+    );
+  }
 }

--- a/backend/src/place/dto/CreatePlaceRequest.ts
+++ b/backend/src/place/dto/CreatePlaceRequest.ts
@@ -6,7 +6,7 @@ import {
 } from 'class-validator';
 import { Place } from '../place.entity';
 
-export class CreatePlaceDto {
+export class CreatePlaceRequest {
   @IsString()
   @IsNotEmpty()
   googlePlaceId: string;

--- a/backend/src/place/exception/PlaceNotFoundException.ts
+++ b/backend/src/place/exception/PlaceNotFoundException.ts
@@ -2,11 +2,14 @@ import { BaseException } from '../../common/exception/BaseException';
 import { HttpStatus } from '@nestjs/common';
 
 export class PlaceNotFoundException extends BaseException {
-  constructor() {
+  constructor(id?: number) {
+    const message = id
+      ? `id:${id} 장소가 존재하지 않습니다.`
+      : '장소가 존재하지 않습니다.';
     super({
       code: 1002,
-      message: '해당 장소가 존재하지 않습니다.',
-      status: HttpStatus.NO_CONTENT,
+      message,
+      status: HttpStatus.NOT_FOUND,
     });
   }
 }

--- a/backend/src/place/exception/PlaceNotFoundException.ts
+++ b/backend/src/place/exception/PlaceNotFoundException.ts
@@ -5,7 +5,7 @@ export class PlaceNotFoundException extends BaseException {
   constructor() {
     super({
       code: 1002,
-      message: '검색 결과가 없습니다.',
+      message: '해당 장소가 존재하지 않습니다.',
       status: HttpStatus.NO_CONTENT,
     });
   }

--- a/backend/src/place/place.controller.ts
+++ b/backend/src/place/place.controller.ts
@@ -1,13 +1,13 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { PlaceService } from './place.service';
-import { CreatePlaceDto } from './dto/CreatePlaceDto';
+import { CreatePlaceRequest } from './dto/CreatePlaceRequest';
 
 @Controller('places')
 export class PlaceController {
   constructor(private readonly placeService: PlaceService) {}
 
   @Post()
-  async addPlace(@Body() createPlaceDto: CreatePlaceDto) {
+  async addPlace(@Body() createPlaceDto: CreatePlaceRequest) {
     return this.placeService.addPlace(createPlaceDto);
   }
 

--- a/backend/src/place/place.entity.ts
+++ b/backend/src/place/place.entity.ts
@@ -29,4 +29,27 @@ export class Place extends BaseEntity {
 
   @Column({ nullable: true })
   detailPageUrl?: string;
+
+  constructor(
+    googlePlaceId: string,
+    name: string,
+    thumbnailUrl: string,
+    rating: number,
+    longitude: number,
+    latitude: number,
+    formattedAddress: string,
+    description: string,
+    detailPageUrl: string,
+  ) {
+    super();
+    this.googlePlaceId = googlePlaceId;
+    this.name = name;
+    this.thumbnailUrl = thumbnailUrl;
+    this.rating = rating;
+    this.longitude = longitude;
+    this.latitude = latitude;
+    this.formattedAddress = formattedAddress;
+    this.description = description;
+    this.detailPageUrl = detailPageUrl;
+  }
 }

--- a/backend/src/place/place.service.ts
+++ b/backend/src/place/place.service.ts
@@ -37,7 +37,7 @@ export class PlaceService {
   async getPlace(id: number) {
     const place = await this.placeRepository.findById(id);
     if (!place) {
-      throw new PlaceNotFoundException();
+      throw new PlaceNotFoundException(id);
     }
     return place;
   }

--- a/backend/src/place/place.service.ts
+++ b/backend/src/place/place.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PlaceRepository } from './place.repository';
-import { CreatePlaceDto } from './dto/CreatePlaceDto';
+import { CreatePlaceRequest } from './dto/CreatePlaceRequest';
 import { PlaceNotFoundException } from './exception/PlaceNotFoundException';
 import { PlaceAlreadyExistsException } from './exception/PlaceAlreadyExistsException';
 
@@ -8,13 +8,13 @@ import { PlaceAlreadyExistsException } from './exception/PlaceAlreadyExistsExcep
 export class PlaceService {
   constructor(private readonly placeRepository: PlaceRepository) {}
 
-  async addPlace(createPlaceDto: CreatePlaceDto) {
-    const { googlePlaceId } = createPlaceDto;
+  async addPlace(createPlaceRequest: CreatePlaceRequest) {
+    const { googlePlaceId } = createPlaceRequest;
     if (await this.placeRepository.findByGooglePlaceId(googlePlaceId)) {
       throw new PlaceAlreadyExistsException();
     }
 
-    const place = createPlaceDto.toEntity();
+    const place = createPlaceRequest.toEntity();
     const savedPlace = await this.placeRepository.save(place);
     return { id: savedPlace.id };
   }


### PR DESCRIPTION
## 📄 Summary

- `SoftDeleteRepository`에서 `where` 절을 배열로 받는 경우 처리를 위해 코드 수정
- `Place`에서 TypeORM `Repository`를 상속받은 `SoftDeleteRepository`로 리팩토링
- pagination 대비 `service`에 파라미터 추가
- 장소 상세 조회 api 에서 장소가 없는 경우 예외 추가
- Query Param을 이용해서 기존 장소의 이름 검색 기능에다가 장소의 주소 검색 기능 추가

## 🙋🏻 More

참고 : [Find Options | typeorm](https://orkhan.gitbook.io/typeorm/docs/find-options)

`where` 에서 대괄호 -> OR / 중괄호 -> AND

```ts

where - simple conditions by which entity should be queried.


userRepository.find({
    where: {
        firstName: "Timber",
        lastName: "Saw",
    },
})

will execute following query:


SELECT * FROM "user"
WHERE "firstName" = 'Timber' AND "lastName" = 'Saw'
```

```ts
userRepository.find({
    where: [
        { firstName: "Timber", lastName: "Saw" },
        { firstName: "Stan", lastName: "Lee" },
    ],
})
will execute following query:

Copy
SELECT * FROM "user" WHERE ("firstName" = 'Timber' AND "lastName" = 'Saw') OR ("firstName" = 'Stan' AND "lastName" = 'Lee')
```

### 🕰️ Actual Time of Completion

> 2.5


close #52