### PR TITLE
코스 순서 저장 방식 개선

### DIFF
--- a/backend/src/course/course.module.ts
+++ b/backend/src/course/course.module.ts
@@ -4,9 +4,11 @@ import { CourseController } from './course.controller';
 import { UserModule } from '../user/user.module';
 import { CourseRepository } from './course.repository';
 import { PlaceModule } from '../place/place.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CoursePlace } from '@src/course/entity/course-place.entity';
 
 @Module({
-  imports: [UserModule, PlaceModule],
+  imports: [UserModule, PlaceModule, TypeOrmModule.forFeature([CoursePlace])],
   controllers: [CourseController],
   providers: [CourseService, CourseRepository],
 })

--- a/backend/src/course/course.service.ts
+++ b/backend/src/course/course.service.ts
@@ -118,7 +118,7 @@ export class CourseService {
     );
 
     course.setPlaces(setPlacesOfCourseRequest.places);
-    await this.courseRepository.save(course); // Todo. Q.바로 장소 조회하면 장소 정보가 없음.. (장소 참조만 객체에 저장했기 때문)
+    await this.courseRepository.updateCoursePlaceById(course);
     const reloadedCourse = await this.courseRepository.findById(course.id);
 
     return {


### PR DESCRIPTION
## 📄 Summary

> Bulk 쿼리 사용해 코스 순서 저장 방식 개선

## 🙋🏻 More

### 실험 결과

https://languid-pluto-1b6.notion.site/143d612fb50c800398f0cfdad29e0914

### Linked List 방식
먼저 실험 결과가 잘 나온 방식으로 시도

1. 새 Linked List 를 만들어 `Course` 의 `CoursePlace` 배열을 대체해 저장
-> 기존의 방식과 차이가 보이지 않음.

2. 변경된 부분만 prev 업데이트 하여 저장
-> 중간에 새 장소가 추가되는 경우 처리 불가

### Bulk 쿼리 이용한 PUT 방식
- `CoursePlace` 에 대한 레포지토리 사용
- bulk 쿼리로 코스에 추가된 장소들 모두 삭제 -> 새 배열 삽입 두 번의 쿼리 사용

### 추가 실험
1. 업데이트 전 장소 유효성 검사는 비동기적 select 문을 실행하기 때문에 전체 성능에 크게 영향을 미치지 않는다.
2. 업데이트 후 장소 정보 조회 또한 비동기적으로 실행되어 전체 성은에 크게 영향을 미치지 않는다.

### 결론
기존 PUT 방식을 개선한 Bulk 쿼리 이용한 방식 사용.

**80**개 장소가 추가된 코스 기준
**1200~1500ms** -> **200~300ms** 로 **81.48%** 가량 처리 시간 감소

기존 대비 **18.52%** 의 시간 소요
평균 **1100ms**의 속도 개선 달성


### 🕰️ Actual Time of Completion

> 12
