### PR TITLE
OAuth api 동작 수정 / 로그 재연결 / 의문의 서버 종료 처리

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "reflect-metadata": "^0.2.0",
     "nestjs-pino": "^4.1.0",
     "pino-http": "^10.3.0",
+    "pino-socket": "^7.4.0",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.20",
     "@nestjs/elasticsearch": "^10.0.2",

--- a/backend/resources/scripts/elk/kibana/level.painless
+++ b/backend/resources/scripts/elk/kibana/level.painless
@@ -1,25 +1,30 @@
+String keyword = "level";
+
+String key = "\"" + keyword + "\":\"";
+
 if (!params['_source'].containsKey('message')) {
-  emit("no message");
+  emit("no stack");
   return;
 }
 
 String message = params['_source']['message'];
 if (message == null) {
-  emit("message is null");
+  emit("no stack");
   return;
 }
 
-// "level":" 를 기준으로 값 추출
-int startIndex = message.indexOf('"level":"');
+int startIndex = message.indexOf(key);
+int key_length =key.length();
+
 if (startIndex == -1) {
-  emit("no msg in message");
+  emit("no message");
   return;
 }
 
-startIndex += 9; // "level":"의 길이만큼 이동
+startIndex += key_length;
 int endIndex = message.indexOf('"', startIndex);
 if (endIndex == -1) {
-  emit("no end of msg");
+  emit("no message");
   return;
 }
 

--- a/backend/resources/scripts/elk/kibana/multi.painless
+++ b/backend/resources/scripts/elk/kibana/multi.painless
@@ -1,0 +1,32 @@
+def keywords = ["msg", "message", "error"];
+String key = null;
+
+if (!params['_source'].containsKey("message")) {
+  emit("[NONE] : no valid key found");
+  return;
+}
+
+String message = params['_source']['message'];
+if (message == null) {
+  emit("[NONE] : no valid key found");
+  return;
+}
+
+// 키 후보를 순회하며 값 추출
+for (String keyword : keywords) {
+  String candidateKey = "\"" + keyword + "\":\"";
+  int startIndex = message.indexOf(candidateKey);
+  if (startIndex != -1) { // 키를 찾으면 값 추출
+    key = candidateKey;
+    int keyLength = candidateKey.length();
+    startIndex += keyLength;
+    int endIndex = message.indexOf("\"", startIndex);
+    if (endIndex != -1) {
+      emit(message.substring(startIndex, endIndex));
+      return;
+    }
+  }
+}
+
+// 매칭되는 키가 없을 경우 "[NONE] : message 내용" 반환
+emit("[NONE] : " + message);

--- a/backend/resources/scripts/elk/kibana/stack.painless
+++ b/backend/resources/scripts/elk/kibana/stack.painless
@@ -1,23 +1,20 @@
+String keyword = "stack";
+
+String key = "\"" + keyword + "\":\"";
+
 if (!params['_source'].containsKey('message')) {
-  emit("no message");
+  emit("no stack");
   return;
 }
 
 String message = params['_source']['message'];
 if (message == null) {
-  emit("no message");
+  emit("no stack");
   return;
 }
 
-// "msg":" 를 기준으로 값 추출
-int startIndex = message.indexOf("\"msg\":\"");
-int key_length = "\"msg\":\"".length();
-
-// 없다면 "message":" 를 기준으로 값 추출
-if (startIndex == -1) {
-  startIndex = message.indexOf("\"message\":\"");
-  key_length = "\"message\":\"".length();
-}
+int startIndex = message.indexOf(key);
+int key_length =key.length();
 
 if (startIndex == -1) {
   emit("no message");

--- a/backend/resources/scripts/elk/logstash/logstash.conf
+++ b/backend/resources/scripts/elk/logstash/logstash.conf
@@ -5,24 +5,38 @@ input {
 
     tcp {
         port => 50000
-        codec => json_lines # JSON 형태의 데이터를 처리
+        codec => json_lines {
+                target => "parsed_message"
+        }
     }
 }
 
 filter {
-    json {
-        source => "message"
-        target => "parsed_message"
+    # 공통 필드 추출
+    mutate {
+        add_field => { "log_level" => "%{[parsed_message][level]}" }
+        add_field => { "log_message" => "%{[parsed_message][msg]}" }
+        add_field => { "request_method" => "%{[parsed_message][req][method]}" }
+        add_field => { "request_url" => "%{[parsed_message][req][url]}" }
     }
 
-    mutate {
-        rename => { "[parsed_message][level]" => "log_level" }
-        rename => { "[parsed_message][msg]" => "log_message" }
-        rename => { "[parsed_message][time]" => "@timestamp" }
+    # 에러인 경우 stack 필드 처리
+    if [parsed_message][stack] {
+        mutate {
+            add_field => { "log_stack" => "%{[parsed_message][stack]}" }
+        }
+    } else {
+        mutate {
+            add_field => { "log_stack" => "no message" }
+        }
+    }
 
-        remove_field => ["message", "parsed_message"]
+    # 불필요한 임시 필드 제거
+    mutate {
+        remove_field => ["parsed_message", "message"]
     }
 }
+
 
 output {
     elasticsearch {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,18 +11,29 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Get(':provider/signIn')
-  async getSignInUrl(@Param('provider') provider: string) {
-    return this.authService.getSignInUrl(getOAuthProviderNameByValue(provider));
+  async getSignInUrl(
+    @Param('provider') provider: string,
+    @Req() request: Request,
+  ) {
+    const origin = request.headers.origin;
+
+    return this.authService.getSignInUrl(
+      getOAuthProviderNameByValue(provider),
+      origin,
+    );
   }
 
   @Post(':provider/signIn')
   async handleCallback(
     @Param('provider') provider: string,
     @Body('code') code: string,
+    @Req() request: Request,
     @Res() response: Response,
   ) {
+    const origin = request.headers.origin;
     const tokens = await this.authService.signInWith(
       getOAuthProviderNameByValue(provider),
+      origin,
       code,
     );
 

--- a/backend/src/auth/oauthProvider/GoogleOAuthProvider.ts
+++ b/backend/src/auth/oauthProvider/GoogleOAuthProvider.ts
@@ -14,16 +14,16 @@ export class GoogleOAuthProvider extends OAuthProvider {
     super(OAuthProviders.GOOGLE, configService);
   }
 
-  getAuthUrl(): string {
+  getAuthUrl(origin: string): string {
     const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
     url.searchParams.append('client_id', this.clientId);
-    url.searchParams.append('redirect_uri', this.redirectUri);
+    url.searchParams.append('redirect_uri', this.getRedirectUrl(origin));
     url.searchParams.append('response_type', 'code');
     url.searchParams.append('scope', 'openid profile');
     return url.toString();
   }
 
-  private async getToken(code: string): Promise<string> {
+  private async getToken(origin: string, code: string): Promise<string> {
     const response = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
       headers: {
@@ -33,7 +33,7 @@ export class GoogleOAuthProvider extends OAuthProvider {
         code: decodeURIComponent(code),
         client_id: this.clientId,
         client_secret: this.clientSecret,
-        redirect_uri: this.redirectUri,
+        redirect_uri: this.getRedirectUrl(origin),
         grant_type: 'authorization_code',
       }),
     });
@@ -45,8 +45,8 @@ export class GoogleOAuthProvider extends OAuthProvider {
     return data.access_token;
   }
 
-  async getUserInfo(code: string): Promise<OAuthUserInfo> {
-    const token = await this.getToken(code);
+  async getUserInfo(origin: string, code: string): Promise<OAuthUserInfo> {
+    const token = await this.getToken(origin, code);
     const response = await fetch(
       'https://www.googleapis.com/oauth2/v2/userinfo',
       {

--- a/backend/src/common/log/CustomLoggerModule.ts
+++ b/backend/src/common/log/CustomLoggerModule.ts
@@ -10,6 +10,7 @@ import { ConfigService, ConfigModule } from '@nestjs/config';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
+        isGlobal: true,
         pinoHttp: {
           logger: createLogger(
             configService.get('LOG_HOST'),

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as cookieParser from 'cookie-parser';
 import { ValidationPipe } from '@nestjs/common';
-import { Logger } from 'nestjs-pino';
+import { Logger, PinoLogger } from 'nestjs-pino';
 import {
   UnknownExceptionFilter,
   HttpExceptionFilter,
@@ -16,16 +16,29 @@ process.env.NODE_ENV =
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
-  app.useLogger(app.get(Logger));
-  app.use(cookieParser());
+  const logger = app.get(Logger);
 
+  app.useLogger(logger);
+  app.use(cookieParser());
   app.useGlobalFilters(
-    new UnknownExceptionFilter(app.get(Logger)),
-    new HttpExceptionFilter(app.get(Logger)),
-    new BaseExceptionFilter(app.get(Logger)),
+    new UnknownExceptionFilter(logger as unknown as PinoLogger),
+    new HttpExceptionFilter(logger as unknown as PinoLogger),
+    new BaseExceptionFilter(logger as unknown as PinoLogger),
   );
 
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
+  process.on('unhandledRejection', (reason, promise) => {
+    // 버그 원인 파악시까지 컨테이너 로그에도 남기기 위해 console.error 사용
+    console.error('Unhandled Rejection at:', { promise, reason });
+    logger.error('Unhandled Rejection at:', { promise, reason });
+  });
+
+  process.on('uncaughtException', (err) => {
+    console.error('Uncaught Exception:', err);
+    logger.error('Uncaught Exception:', err);
+  });
+
   await app.listen(8080);
 }
 

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1427,6 +1427,11 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz"
@@ -1764,6 +1769,13 @@ babel-preset-jest@^29.6.3:
   dependencies:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
+
+backoff@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/backoff/-/backoff-2.5.0.tgz#f616eda9d3e4b66b8ca7fca79f695722c5f8e26f"
+  integrity sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==
+  dependencies:
+    precond "0.2"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -4534,6 +4546,13 @@ node-releases@^2.0.18:
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
 
+nopt@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
+  dependencies:
+    abbrev "^2.0.0"
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
@@ -4785,6 +4804,17 @@ pino-pretty@^13.0.0:
     sonic-boom "^4.0.1"
     strip-json-comments "^3.1.1"
 
+pino-socket@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/pino-socket/-/pino-socket-7.4.0.tgz#86732fd150dd1fc526aa2e004c07d9527cbd29c7"
+  integrity sha512-UBXkwDRz9RM5pG8gWKxxsonmqM3kk0fx8PbueWlg4LywNT2+Jl0C2xGVPNUyNYn5OjbZopodV8d/UZbuKVEf4w==
+  dependencies:
+    backoff "^2.5.0"
+    nopt "^7.0.0"
+    pump "^3.0.0"
+    split2 "^4.0.0"
+    through2 "^4.0.2"
+
 pino-std-serializers@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz"
@@ -4823,6 +4853,11 @@ pluralize@8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
+precond@0.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
+  integrity sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4964,6 +4999,15 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
+readable-stream@3, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@^2.0.5, readable-stream@^2.2.2:
   version "2.3.8"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
@@ -4976,15 +5020,6 @@ readable-stream@^2.0.5, readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
-  version "3.6.2"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readable-stream@^4.0.0:
   version "4.5.2"
@@ -5376,7 +5411,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5408,7 +5452,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5640,6 +5691,13 @@ thread-stream@^3.0.0:
   integrity sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==
   dependencies:
     real-require "^0.2.0"
+
+through2@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
 
 through@^2.3.6:
   version "2.3.8"
@@ -6033,7 +6091,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.0.tgz#4c4d20446dcc670b14fa115ef4f8fd9947af2b3a"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6046,6 +6104,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## 📄 Summary

> 요청 오리진에 맞추어 OAuth api가 동작하도록 수정
`pino-sockek` 이용해 로거 재연결 설정
의문의 서버 종료 처리

## 🙋🏻 More

### `.env` 변경사항
`${PROVIDER}_ALLOWED_ORIGINS` : 쉼표로 구분해 여러 개의 도메인을 등록할 수 있습니다.

![image](https://github.com/user-attachments/assets/791848e6-6619-423c-ab55-83c6d0d86311)

허용되지 않은 도메인에서 요청이 오면 에러를 응답합니다.

![image](https://github.com/user-attachments/assets/b468072e-6cd6-49e6-9eed-7eafe2b16755)


### FE OAuth 로그인 흐름 변경사항
1. `/oauth/google/signIn` 경로로 구글 로그인 url 요청
2.  해당 url 사용해 구글 로그인 ( redirect url 이 현재 요청하는 프론트엔드 오리진으로 설정됨)
3. 이후 기존과 동일

### 로그 재연결 테스트, 의문의 서버 종료 처리는 댓글로 남겼습니다

### 🕰️ Actual Time of Completion

> 3H


close #173