### PR TITLE
테스트에서 PinoLogger 모킹 / 테스트 오류 수정 / 검색 가중치 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,4 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+**/*.pem

--- a/backend/src/search/query/builder/FilterQueryBuilder.ts
+++ b/backend/src/search/query/builder/FilterQueryBuilder.ts
@@ -17,7 +17,7 @@ const createMatchFilter = (field: string, value: string, weight: number) => ({
 });
 
 export const FilterBuilders = {
-  FILTER_TERM_NAME_KEYWORD: (query: string, weight: number = 20) =>
+  FILTER_TERM_NAME_KEYWORD: (query: string, weight: number = 50) =>
     createTermFilter('name.keyword', query, weight),
   FILTER_MATCH_NAME: (token: string, weight: number = 15) =>
     createMatchFilter('name', token, weight),

--- a/backend/test/course/course.service.test.ts
+++ b/backend/test/course/course.service.test.ts
@@ -183,7 +183,11 @@ describe('CourseService', () => {
       currentPage,
       pageSize,
     );
-    expect(result).toEqual(expectedResponse);
+    expect(result).toEqual(
+      expect.objectContaining({
+        courses: expectedResponse.courses,
+      }),
+    );
   });
 
   describe('특정 코스를 조회할 때', () => {


### PR DESCRIPTION
## 📄 Summary

> 테스트에서 `PinoLogger` 모킹 / 테스트 오류 수정 / 검색 가중치 변경

## 🙋🏻 More

- `name.keyword`의 가중치를 20 -> 50 으로 변경

### 🕰️ Actual Time of Completion

> 1


close #courseTest